### PR TITLE
Remove using JailManager in Rules

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+        threshold: 2%

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ blocked_ips.json
 config.yaml
 *.mmdb
 waf
+test/**/*.test.js
+test/**/*.test.js.map
+
+test/Helpers/*.js
+test/Helpers/*.js.map
+
+

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,7 @@ const config: Config = {
     transform: {
         '^.+\\.tsx?$': [
             'ts-jest',
-            { tsconfig: 'tsconfig.json' }
+            { tsconfig: './tsconfig.json' }
         ]
     },
     roots: ['<rootDir>/src', '<rootDir>/test'],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "module": "src/main.ts",
   "scripts": {
     "run": "ts-node src/main.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.app.json",
     "clean": "rimraf dist build coverage",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",

--- a/src/Rules/AbstractRule.ts
+++ b/src/Rules/AbstractRule.ts
@@ -1,7 +1,8 @@
 import {NextFunction, Request, Response} from "express-serve-static-core";
+import {IBannedIPItem} from "@waf/WAFMiddleware";
 
 export abstract class AbstractRule {
-     public abstract use(clientIp: string, req: Request, res: Response, next: NextFunction): Promise<boolean>;
+     public abstract use(clientIp: string, req: Request, res: Response, next: NextFunction): Promise<boolean|IBannedIPItem>;
 
     protected createRegexFromString(regexString: string) {
         //We check whether the line begins with the slash and whether it contains another slash at the end of the pattern

--- a/test/Helpers/DummyRule.ts
+++ b/test/Helpers/DummyRule.ts
@@ -1,16 +1,18 @@
-import {AbstractRule} from "../../src/Rules/AbstractRule";
 import {NextFunction, Request, Response} from "express-serve-static-core";
+import {IBannedIPItem} from "@waf/WAFMiddleware";
+import {AbstractRule} from "@waf/Rules/AbstractRule";
+
 
 
 export class DummyRule extends AbstractRule {
 
     public constructor(
-        private readonly response:boolean
+        private readonly response:boolean|IBannedIPItem
     ) {
         super();
     }
 
-    public use(clientIp: string, req: Request, res: Response, next: NextFunction): Promise<boolean> {
+    public use(clientIp: string, req: Request, res: Response, next: NextFunction): Promise<boolean|IBannedIPItem> {
         return Promise.resolve(this.response);
     }
 

--- a/test/unit/Api.test.ts
+++ b/test/unit/Api.test.ts
@@ -1,6 +1,7 @@
-import {Api, IApiConfig} from "../../src/Api";
+
 import express, {NextFunction, Request, Response} from "express";
 import httpMocks from "node-mocks-http";
+import {Api, IApiConfig} from "@waf/Api";
 
 describe('Api Authentication Middleware', () => {
     let service: Api;

--- a/test/unit/Rules/CompositeRule.test.ts
+++ b/test/unit/Rules/CompositeRule.test.ts
@@ -1,18 +1,9 @@
-import {BanInfo, JailManager} from "../../../src/Jail/JailManager";
-import {CompositeRule} from "../../../src/Rules/CompositeRule";
 // @ts-ignore
 import httpMocks from "node-mocks-http";
+import {CompositeRule} from "@waf/Rules/CompositeRule";
 
 describe('CompositeRule test', () => {
     let rule: CompositeRule
-    JailManager.build({
-        syncAlways: true
-    }, global.jailStorage)
-    JailManager.instance.onStop();
-
-    beforeEach(() => {
-        global.jailStorage.save([]);
-    });
 
     it('Equal url match', async () => {
         rule = new CompositeRule({
@@ -41,14 +32,11 @@ describe('CompositeRule test', () => {
         let result = await rule.use('1.1.1.1', request, response, next);
         expect(result).toEqual(false);
         result = await rule.use('1.1.1.1', request, response, next);
-        expect(result).toEqual(true);
+        expect(result).toEqual({"duration": 10, "escalationRate": 1, "ip": "1.1.1.1", "ruleId": "composite"});
 
-        const bannedIps: BanInfo[] = await global.jailStorage.load()
-        expect(bannedIps.length).toEqual(1);
 
     });
     it('Equal url not match', async () => {
-
         rule = new CompositeRule({
             type: 'composite',
             duration: 10,
@@ -61,6 +49,7 @@ describe('CompositeRule test', () => {
                 value: '/test'
             }
         });
+
         const request = httpMocks.createRequest({
             method: 'GET',
             url: '/test-not-match',
@@ -76,10 +65,9 @@ describe('CompositeRule test', () => {
         result = await rule.use('1.1.1.1', request, response, next);
         expect(result).toEqual(false);
 
-        const bannedIps: BanInfo[] = await global.jailStorage.load()
-        expect(bannedIps.length).toEqual(0);
 
     });
+
     it('Regexp url match', async () => {
 
         rule = new CompositeRule({
@@ -107,15 +95,13 @@ describe('CompositeRule test', () => {
         let result = await rule.use('1.1.1.1', request, response, next);
         expect(result).toEqual(false);
         result = await rule.use('1.1.1.1', request, response, next);
-        expect(result).toEqual(true);
+        expect(result).toEqual({"duration": 10, "escalationRate": 1, "ip": "1.1.1.1", "ruleId": "composite"});
 
-        const bannedIps: BanInfo[] = await global.jailStorage.load()
-        expect(bannedIps.length).toEqual(1);
 
     });
 
 
-    it('Regexp url not match', async () => {
+    it('Regexp not match', async () => {
 
         rule = new CompositeRule({
             type: 'composite',
@@ -143,9 +129,6 @@ describe('CompositeRule test', () => {
         expect(result).toEqual(false);
         result = await rule.use('1.1.1.1', request, response, next);
         expect(result).toEqual(false);
-
-        const bannedIps: BanInfo[] = await global.jailStorage.load()
-        expect(bannedIps.length).toEqual(0);
 
     });
 

--- a/test/unit/Rules/FlexibleRule.test.ts
+++ b/test/unit/Rules/FlexibleRule.test.ts
@@ -1,14 +1,9 @@
 import {FlexibleRule} from "../../../src/Rules/FlexibleRule";
-import {BanInfo, JailManager} from "../../../src/Jail/JailManager";
 // @ts-ignore
 import httpMocks from "node-mocks-http";
 
 describe('FlexibleRule test', () => {
     let rule: FlexibleRule
-    JailManager.build({
-        syncAlways: true
-    }, global.jailStorage)
-    JailManager.instance.onStop();
 
     describe('FlexibleRule test url', () => {
 
@@ -32,7 +27,6 @@ describe('FlexibleRule test', () => {
                 ]
 
             });
-            global.jailStorage.save([]);
         });
 
         it('Equal url match', async () => {
@@ -47,10 +41,8 @@ describe('FlexibleRule test', () => {
             let result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
-            expect(result).toEqual(true);
+            expect(result).toEqual({"duration": 10, "escalationRate": 1, "ip": "1.1.1.1", "ruleId": "flexible"});
 
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(1);
 
         });
 
@@ -66,10 +58,7 @@ describe('FlexibleRule test', () => {
             let result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
-            expect(result).toEqual(true);
-
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(1);
+            expect(result).toEqual({"duration": 10, "escalationRate": 1, "ip": "1.1.1.1", "ruleId": "flexible"});
 
         });
 
@@ -86,9 +75,6 @@ describe('FlexibleRule test', () => {
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
-
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(0);
 
         });
 
@@ -138,10 +124,7 @@ describe('FlexibleRule test', () => {
             let result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
-            expect(result).toEqual(true);
-
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(1);
+            expect(result).toEqual({"duration": 10, "escalationRate": 1, "ip": "1.1.1.1", "ruleId": "flexible"});
 
         });
 
@@ -160,10 +143,7 @@ describe('FlexibleRule test', () => {
             let result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
-            expect(result).toEqual(true);
-
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(1);
+            expect(result).toEqual({"duration": 10, "escalationRate": 1, "ip": "1.1.1.1", "ruleId": "flexible"});
 
         });
 
@@ -182,9 +162,6 @@ describe('FlexibleRule test', () => {
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
-
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(0);
 
         });
 
@@ -232,10 +209,7 @@ describe('FlexibleRule test', () => {
             let result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
-            expect(result).toEqual(true);
-
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(1);
+            expect(result).toEqual({"duration": 10, "escalationRate": 1, "ip": "1.1.1.1", "ruleId": "flexible"});
 
         });
 
@@ -254,10 +228,7 @@ describe('FlexibleRule test', () => {
             let result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
-            expect(result).toEqual(true);
-
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(1);
+            expect(result).toEqual({"duration": 10, "escalationRate": 1, "ip": "1.1.1.1", "ruleId": "flexible"});
 
         });
 
@@ -276,9 +247,6 @@ describe('FlexibleRule test', () => {
             expect(result).toEqual(false);
             result = await rule.use('1.1.1.1', request, response, next);
             expect(result).toEqual(false);
-
-            const bannedIps: BanInfo[] = await global.jailStorage.load()
-            expect(bannedIps.length).toEqual(0);
 
         });
 

--- a/test/unit/Whitelist.test.ts
+++ b/test/unit/Whitelist.test.ts
@@ -1,5 +1,6 @@
 import {IWhitelistConfig, Whitelist} from "@waf/Whitelist";
 
+
 describe('Whitelist', () => {
     const config: IWhitelistConfig = {
         ips: ['192.168.1.1', '10.0.0.1'],

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules/**",
+    "test/**/*"
+  ],
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "types": [
+      "node",
+    ],
+    "rootDirs": ["src", "test"],
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,9 @@
 {
   "extends": "./tsconfig.base.json",
-  "exclude": [
-    "node_modules/**"
-  ],
-  "include": ["src"],
+  "exclude": ["node_modules/**"],
+  "include": ["src", "test"],
   "compilerOptions": {
-    "types": [
-      "node",
-      "jest"
-    ],
+    "types": ["jest"],
     "typeRoots": [
       "node_modules/@types",
       "@types",


### PR DESCRIPTION
Refactor rule logic to return IP blocking metadata.

Updated `AbstractRule` and its implementations to return detailed `IBannedIPItem` metadata instead of directly invoking `blockIp`. Enhanced test cases and middleware to process this metadata for IP blocking. Improved configuration setup and streamlined test fixtures for consistency.