### PR TITLE
Reset counters after handling rule violations

### DIFF
--- a/src/Jail/Rules/CompositeRule.ts
+++ b/src/Jail/Rules/CompositeRule.ts
@@ -71,13 +71,15 @@ export class CompositeRule extends ConditionsRule {
         // If the number of queries exceeds the limit, we block IP
         if (this.compositeCounters[compositeKey].length >= (this.rule.limit || 100)) {
             this.log.info(`The composite rule worked for ${clientIp} (key: ${compositeKey}). request: ${this.compositeCounters[compositeKey].length}`);
-            return Promise.resolve({
+            const requestIds = this.compositeCounters[compositeKey].map(item => item.requestId);
+            this.compositeCounters[compositeKey] = []; // reset counter to 0;
+            return {
                 ruleId: CompositeRule.ID+ ':' + this.rule.name,
                 ip: clientIp,
                 duration: this.rule.duration,
                 escalationRate: this.rule?.escalationRate || 1.0,
-                requestIds: this.compositeCounters[compositeKey].map(item => item.requestId),
-            })
+                requestIds: requestIds
+            };
         }
 
         return Promise.resolve(false);

--- a/src/Jail/Rules/FlexibleRule.ts
+++ b/src/Jail/Rules/FlexibleRule.ts
@@ -50,12 +50,14 @@ export class FlexibleRule extends ConditionsRule {
         // If the number of queries exceeds the limit, we block IP
         if (this.suspicions[clientIp].length >= (this.rule.limit || 100)) {
             this.log.info(`Too many suspicious request from ${clientIp}`, []);
+            const requestIds = this.suspicions[clientIp].map(item => item.requestId);
+            this.suspicions[clientIp] = []; // reset counter to 0;
             return {
                 ruleId: FlexibleRule.ID+ ':' + this.rule.name,
                 ip: clientIp,
                 duration: this.rule.duration,
                 escalationRate: this.rule?.escalationRate || 1.0,
-                requestIds: this.suspicions[clientIp].map(item => item.requestId),
+                requestIds: requestIds,
             }
         }
 


### PR DESCRIPTION
Added logic to reset counters for CompositeRule and FlexibleRule once the violation is handled, ensuring accurate tracking for subsequent requests. Introduced intermediate variables to capture request IDs before resetting counters, improving maintainability and clarity.