### PR TITLE
Add escalationCount to jail metrics and test cases

### DIFF
--- a/src/Jail/JailManager.ts
+++ b/src/Jail/JailManager.ts
@@ -105,7 +105,7 @@ export class JailManager extends Singleton<JailManager, []>{
         this.metrics['storage_data'] = new promClient.Gauge({
             name: 'waf_jail_storage_data',
             help: 'How many data in storage grouped by ruleId, country, city, isBlocked',
-            labelNames: ['country', 'city', 'ruleId', 'isBlocked'],
+            labelNames: ['country', 'city', 'ruleId', 'isBlocked', 'escalationCount'],
             registers: [this.metricsInstance.getRegisters()]
         });
     }
@@ -235,12 +235,12 @@ export class JailManager extends Singleton<JailManager, []>{
         for (const entry of Object.values(this.blockedIPs)) {
             const { ruleId, country, city } = entry.metadata;
             const isBlocked = Date.now() < entry.unbanTime;
-            const key = `${ruleId}|||${country}|||${city}|||${isBlocked}`;
+            const key = `${ruleId}|||${country}|||${city}|||${isBlocked}|||${entry.escalationCount}`;
             counts.set(key, (counts.get(key) ?? 0) + 1);
         }
         for (const [key, value] of counts.entries()) {
-            const [ruleId, country, city, isBlocked] = key.split('|||');
-            this.metrics['storage_data']?.set({ ruleId, country, city, isBlocked}, value);
+            const [ruleId, country, city, isBlocked, escalationCount] = key.split('|||');
+            this.metrics['storage_data']?.set({ ruleId, country, city, isBlocked, escalationCount}, value);
         }
     }
     private mergeBanLists(

--- a/test/unit/Jail/JailManager.test.ts
+++ b/test/unit/Jail/JailManager.test.ts
@@ -317,6 +317,7 @@ describe('Jail Manager', () => {
                              "labels": {
                                  "city": "Chicago",
                                  "country": "USA",
+                                 "escalationCount": "1",
                                  "isBlocked": "true",
                                  "ruleId": "local"
                              },
@@ -326,6 +327,7 @@ describe('Jail Manager', () => {
                              "labels": {
                                  "city": "Los Angeles",
                                  "country": "USA",
+                                 "escalationCount": "2",
                                  "isBlocked": "false",
                                  "ruleId": "remote"
                              },
@@ -337,4 +339,5 @@ describe('Jail Manager', () => {
 
          });
      });
+
  });


### PR DESCRIPTION
Updated the metrics tracking in JailManager to include the `escalationCount` label in both the Prometheus gauge setup and data aggregation logic. Corresponding test cases were modified to reflect and validate this new attribute.